### PR TITLE
chore: add fetch workflow

### DIFF
--- a/.github/workflows/fetch.yml
+++ b/.github/workflows/fetch.yml
@@ -1,0 +1,39 @@
+name: Update game data
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fetch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install mise
+        uses: jdx/mise-action@c37c93293d6b742fc901e1406b8f764f6fb19dac
+
+      - name: Trust mise config
+        run: mise trust
+
+      - name: Fetch Hive games
+        run: mise run fetch-hive
+
+      - name: Commit and push changes
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add -A
+            git commit -m "chore: update game data"
+            git push origin HEAD:main
+          else
+            echo 'No changes to commit'
+          fi


### PR DESCRIPTION
## Summary
- add scheduled workflow to fetch and cache game data
- pin mise action commit and call fetch-hive task directly

## Testing
- `pnpm exec vitest run`


------
https://chatgpt.com/codex/tasks/task_e_68b5e717f154832ba5933392a638334b