### PR TITLE
Add automatic dark mode to Hive pages

### DIFF
--- a/app/hive/HiveThemeWatcher.tsx
+++ b/app/hive/HiveThemeWatcher.tsx
@@ -1,0 +1,36 @@
+"use client"
+
+import { useEffect } from "react"
+
+/**
+ * Keeps the Hive pages in sync with the user's preferred color scheme.
+ *
+ * When mounted we apply the system preference and listen for changes.
+ * On unmount we restore the previous dark-mode state so that other routes
+ * are unaffected by the Hive pages' automatic theming.
+ */
+export default function HiveThemeWatcher() {
+  useEffect(() => {
+    if (typeof window === "undefined") return
+
+    const root = document.documentElement
+    const hadDarkClass = root.classList.contains("dark")
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)")
+
+    const applyTheme = () => {
+      if (mediaQuery.matches) root.classList.add("dark")
+      else root.classList.remove("dark")
+    }
+
+    applyTheme()
+    mediaQuery.addEventListener("change", applyTheme)
+
+    return () => {
+      mediaQuery.removeEventListener("change", applyTheme)
+      if (hadDarkClass) root.classList.add("dark")
+      else root.classList.remove("dark")
+    }
+  }, [])
+
+  return null
+}

--- a/app/hive/Tabs.tsx
+++ b/app/hive/Tabs.tsx
@@ -16,8 +16,8 @@ export default function Tabs() {
         className={cn(
           "px-4 py-2 rounded font-medium transition-colors",
           isMain
-            ? "bg-blue-100 text-blue-800"
-            : "bg-gray-100 hover:bg-gray-200 text-gray-700",
+            ? "bg-blue-100 text-blue-800 dark:bg-blue-500/20 dark:text-blue-100"
+            : "bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-800/60 dark:hover:bg-gray-700/60 dark:text-gray-200",
         )}
       >
         Player stats
@@ -27,8 +27,8 @@ export default function Tabs() {
         className={cn(
           "px-4 py-2 rounded font-medium transition-colors",
           isRecent
-            ? "bg-blue-100 text-blue-800"
-            : "bg-gray-100 hover:bg-gray-200 text-gray-700",
+            ? "bg-blue-100 text-blue-800 dark:bg-blue-500/20 dark:text-blue-100"
+            : "bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-800/60 dark:hover:bg-gray-700/60 dark:text-gray-200",
         )}
       >
         Recent games

--- a/app/hive/layout.tsx
+++ b/app/hive/layout.tsx
@@ -1,12 +1,13 @@
-import { cn } from "@/lib/utils"
-import Link from "next/link"
 import { ReactNode } from "react"
+
+import HiveThemeWatcher from "./HiveThemeWatcher"
 import Tabs from "./Tabs"
 
 export default function HiveLayout({ children }: { children: ReactNode }) {
   return (
-    <div className="w-[100vw] m-0 bg-white rounded-none shadow-none overflow-visible">
-      <div className="bg-[linear-gradient(135deg,#667eea_0%,#764ba2_100%)] text-white p-[30px] text-center">
+    <div className="w-[100vw] m-0 bg-background text-foreground rounded-none shadow-none overflow-visible">
+      <HiveThemeWatcher />
+      <div className="bg-gradient-to-r from-indigo-500 via-purple-500 to-purple-600 dark:from-slate-900 dark:via-slate-950 dark:to-slate-900 text-white p-[30px] text-center shadow-sm">
         <h1 className="m-0 text-[2.5em] font-light">🐝 Hive</h1>
       </div>
       <div className="p-5">

--- a/app/hive/page.tsx
+++ b/app/hive/page.tsx
@@ -269,12 +269,12 @@ export default async function Hive() {
         <meta name="description" content="Interactive Hive games table" />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      <main>
-        <div className="w-[100vw] m-0 bg-white rounded-none shadow-none overflow-visible">
+      <main className="bg-background text-foreground">
+        <div className="w-[100vw] m-0 bg-background text-foreground rounded-none shadow-none overflow-visible">
           <div className="p-5">
             <div
               id="hive-table-root"
-              className="overflow-x-auto border-2 border-[#e9ecef] rounded-lg bg-[#f8f9fa] p-5 max-w-6xl mx-auto"
+              className="overflow-x-auto border border-border rounded-lg bg-card dark:bg-muted/30 p-5 max-w-6xl mx-auto shadow-sm dark:shadow-none"
             >
               <HiveTable
                 config={config}

--- a/app/hive/recent/page.tsx
+++ b/app/hive/recent/page.tsx
@@ -258,8 +258,8 @@ export default async function RecentPage() {
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
       </Head>
-      <main>
-        <div className="w-[100vw] m-0 bg-white rounded-none shadow-none overflow-visible">
+      <main className="bg-background text-foreground">
+        <div className="w-[100vw] m-0 bg-background text-foreground rounded-none shadow-none overflow-visible">
           <div className="p-5">
             <RecentGames
               games={recentGames}

--- a/components/HiveTable.tsx
+++ b/components/HiveTable.tsx
@@ -64,16 +64,16 @@ function HiveHeader({
   return (
     <UiTableHeader>
       <UiTableRow>
-        <UiTableHead className="bg-[#f8f9fa] border border-[#dee2e6] p-2 text-center font-bold">
+        <UiTableHead className="bg-muted text-foreground border border-border p-2 text-center font-semibold dark:bg-muted/40">
           Player
         </UiTableHead>
-        <UiTableHead className="bg-[#f8f9fa] border border-[#dee2e6] p-2 text-center font-bold">
+        <UiTableHead className="bg-muted text-foreground border border-border p-2 text-center font-semibold dark:bg-muted/40">
           Total Games
         </UiTableHead>
         {sortedPlayers.map((player) => (
           <UiTableHead
             key={player.id}
-            className="bg-[#f8f9fa] border border-[#dee2e6] p-2 text-center font-bold min-w-20"
+            className="bg-muted text-foreground border border-border p-2 text-center font-semibold min-w-20 dark:bg-muted/40"
           >
             <PlayerInfo player={player} groupColorMap={groupColorMap} />
           </UiTableHead>
@@ -109,11 +109,21 @@ function GameStats({ stats }: { stats: GameStats | undefined }) {
 
   return (
     <>
-      {ratedStats && ratedTotal > 0 && <span>{formatStats(ratedStats)}</span>}
+      {ratedStats && ratedTotal > 0 && (
+        <span className="font-semibold">{formatStats(ratedStats)}</span>
+      )}
       <br />
       {unratedStats && unratedTotal > 0
-        ? <span className="unrated-text">{formatStats(unratedStats)}</span>
-        : <span className="unrated-text">&nbsp;</span>}
+        ? (
+          <span className="text-xs text-muted-foreground dark:text-muted-foreground/80">
+            {formatStats(unratedStats)}
+          </span>
+        )
+        : (
+          <span className="text-xs text-muted-foreground dark:text-muted-foreground/80">
+            &nbsp;
+          </span>
+        )}
     </>
   )
 }
@@ -139,11 +149,11 @@ function PlayerRow({
   return (
     <UiTableRow key={rowPlayer.id}>
       {/* Player name and groups */}
-      <UiTableCell className="bg-[#f8f9fa] border border-[#dee2e6] p-2 text-center font-bold w-[120px] min-w-[120px] max-w-[120px]">
+      <UiTableCell className="bg-muted text-foreground border border-border p-2 text-center font-semibold w-[120px] min-w-[120px] max-w-[120px] dark:bg-muted/40">
         <PlayerInfo player={rowPlayer} groupColorMap={groupColorMap} />
       </UiTableCell>
       {/* Total games */}
-      <UiTableCell className="bg-[#e9ecef] border border-[#dee2e6] p-2 text-center font-bold w-[80px] min-w-[80px] max-w-[80px]">
+      <UiTableCell className="bg-muted text-foreground border border-border p-2 text-center font-semibold w-[80px] min-w-[80px] max-w-[80px] dark:bg-muted/30">
         {rowPlayer.total_games}
       </UiTableCell>
       {/* Game stats (rest of the row) */}
@@ -155,7 +165,7 @@ function PlayerRow({
           <UiTableCell
             key={`${rowPlayer.id}-${colPlayer.id}`}
             className={cn(
-              "border border-[#dee2e6] p-1 text-center min-w-[60px] h-10 align-middle",
+              "border border-border p-1 text-center min-w-[60px] h-10 align-middle",
               cellClass,
             )}
           >
@@ -235,8 +245,10 @@ export default function HiveTable({
     colPlayer: Player,
     stats: GameStats | undefined,
   ) => {
-    if (rowPlayer.id === colPlayer.id) return "bg-[#e9ecef] text-[#6c757d]"
-    if (!stats) return "bg-[#f8f9fa] text-[#6c757d]"
+    if (rowPlayer.id === colPlayer.id)
+      return "bg-muted text-muted-foreground dark:bg-muted/40"
+    if (!stats)
+      return "bg-card text-muted-foreground dark:bg-muted/20"
 
     const ratedTotal = stats.rated_stats
       ? stats.rated_stats.wins
@@ -249,8 +261,9 @@ export default function HiveTable({
         + stats.unrated_stats.draws
       : 0
 
-    if (ratedTotal > 0 || unratedTotal > 0) return "bg-[#e8f5e8]"
-    return "bg-[#f8f9fa] text-[#6c757d]"
+    if (ratedTotal > 0 || unratedTotal > 0)
+      return "bg-emerald-100 text-emerald-900 dark:bg-emerald-500/20 dark:text-emerald-200"
+    return "bg-card text-muted-foreground dark:bg-muted/20"
   }
 
   const getStats = (player1: Player, player2: Player) => {
@@ -260,7 +273,7 @@ export default function HiveTable({
   }
 
   return (
-    <div className="w-full min-w-[1200px] bg-white rounded-lg shadow">
+    <div className="w-full min-w-[1200px] bg-background text-foreground rounded-lg border border-border shadow-sm dark:bg-slate-950/40 dark:shadow-none">
       <div className="min-w-[800px]">
         <UiTable className="w-max text-[12px] border-collapse">
           <HiveHeader

--- a/components/RecentGames.tsx
+++ b/components/RecentGames.tsx
@@ -117,11 +117,11 @@ function determinePlayerOrder(
 function getResultClass(result: "white" | "black" | "draw"): string {
   switch (result) {
     case "white":
-      return "text-green-600 font-semibold"
+      return "text-green-600 dark:text-green-400 font-semibold"
     case "black":
-      return "text-blue-600 font-semibold"
+      return "text-blue-600 dark:text-blue-300 font-semibold"
     case "draw":
-      return "text-gray-600 font-semibold"
+      return "text-gray-600 dark:text-gray-300 font-semibold"
     default:
       return ""
   }
@@ -321,15 +321,17 @@ export default function RecentGames({
         href={`https://hivegame.com/@/${name}`}
         target="_blank"
         rel="noopener noreferrer"
-        className={cn("text-gray-700 hover:text-blue-600")}
+        className={cn(
+          "text-gray-700 hover:text-blue-600 dark:text-gray-200 dark:hover:text-blue-400",
+        )}
         title={displayName}
       >
         <span
           className={cn(
             "px-1.5 py-0.5 rounded transition-colors duration-150",
             shouldHighlight
-              ? "bg-yellow-100 hover:bg-yellow-200"
-              : "bg-gray-100 hover:bg-gray-200",
+              ? "bg-yellow-100 hover:bg-yellow-200 text-yellow-900 dark:bg-yellow-400/20 dark:hover:bg-yellow-400/30 dark:text-yellow-100"
+              : "bg-gray-100 hover:bg-gray-200 text-gray-700 dark:bg-gray-800/60 dark:hover:bg-gray-700/60 dark:text-gray-100",
             isWinner
               ? "border-b-3 border-green-400"
               : "border-b-3 border-transparent",
@@ -345,19 +347,19 @@ export default function RecentGames({
   const groupedGames = groupGamesByDay(processedGames)
 
   return (
-    <div className="w-full bg-white rounded-lg">
+    <div className="w-full bg-card text-foreground rounded-lg border border-border shadow-sm dark:bg-slate-950/40 dark:shadow-none">
       <div className="space-y-6 max-w-5xl mx-auto pt-10">
         {groupedGames.map(([dateKey, dayGames]) => {
           const dayHeader = dayGames.length > 0
             ? formatDayHeader(dayGames[0].timestamp || dateKey)
             : formatDayHeader(dateKey)
           return (
-            <div key={dateKey} className="border-gray-200 pb-6">
+            <div key={dateKey} className="border-border pb-6">
               <div className="flex items-center gap-3 mb-4">
-                <h3 className="text-lg font-semibold text-gray-800">
+                <h3 className="text-lg font-semibold text-gray-800 dark:text-gray-100">
                   {dayHeader}
                 </h3>
-                <span className="text-sm text-gray-600 bg-gray-100 px-2 py-1 rounded">
+                <span className="text-sm text-gray-600 bg-gray-100 px-2 py-1 rounded dark:text-gray-200 dark:bg-gray-800/60">
                   {dayGames.length === 0
                     ? "No games"
                     : `${dayGames.length} game${dayGames.length === 1 ? "" : "s"}`}
@@ -366,7 +368,7 @@ export default function RecentGames({
 
               {dayGames.length === 0
                 ? (
-                  <div className="text-center py-8 text-gray-500 bg-gray-50 rounded-lg border border-gray-200">
+                  <div className="text-center py-8 text-muted-foreground bg-muted/40 rounded-lg border border-border dark:bg-muted/20">
                     <p className="text-sm">No games played on this day</p>
                   </div>
                 )
@@ -375,13 +377,13 @@ export default function RecentGames({
                     <Table className="min-w-[700px] table-fixed">
                       <TableHeader>
                         <TableRow>
-                          <TableHead className="bg-[#f8f9fa] border border-[#dee2e6] p-3 text-left font-bold w-1/4">
+                          <TableHead className="bg-muted text-foreground border border-border p-3 text-left font-semibold w-1/4 dark:bg-muted/40">
                             Event
                           </TableHead>
-                          <TableHead className="bg-[#f8f9fa] border border-[#dee2e6] p-3 text-left font-bold">
+                          <TableHead className="bg-muted text-foreground border border-border p-3 text-left font-semibold dark:bg-muted/40">
                             Match
                           </TableHead>
-                          <TableHead className="bg-[#f8f9fa] border border-[#dee2e6] p-3 text-center font-bold w-24">
+                          <TableHead className="bg-muted text-foreground border border-border p-3 text-center font-semibold w-24 dark:bg-muted/40">
                             Rated
                           </TableHead>
                         </TableRow>
@@ -390,21 +392,21 @@ export default function RecentGames({
                         {dayGames.map((game: ProcessedGame) => (
                           <TableRow
                             key={game.game_id}
-                            className="hover:bg-gray-50"
+                            className="hover:bg-muted/50 dark:hover:bg-muted/20"
                           >
-                            <TableCell className="border border-[#dee2e6] p-3">
+                            <TableCell className="border border-border p-3">
                               <span
                                 className={cn(
                                   "text-sm",
                                   game.event
-                                    ? "text-purple-700 font-medium bg-purple-50 px-2 py-1 rounded"
-                                    : "text-gray-400 italic",
+                                    ? "text-purple-700 dark:text-purple-300 font-medium bg-purple-50 dark:bg-purple-500/20 px-2 py-1 rounded"
+                                    : "text-gray-400 dark:text-gray-500 italic",
                                 )}
                               >
                                 {game.event || "—"}
                               </span>
                             </TableCell>
-                            <TableCell className="border border-[#dee2e6] p-3">
+                            <TableCell className="border border-border p-3">
                               <div className="flex items-center gap-2 flex-wrap">
                                 <InlinePlayerTag
                                   name={game.playerOrder.playerOne.name}
@@ -413,7 +415,7 @@ export default function RecentGames({
                                     && game.playerOrder.playerOne.originalColor
                                       === (game.result as "white" | "black")}
                                 />
-                                <span className="text-gray-400">vs</span>
+                                <span className="text-gray-400 dark:text-gray-500">vs</span>
                                 <InlinePlayerTag
                                   name={game.playerOrder.playerTwo.name}
                                   known={game.playerOrder.playerTwo.known}
@@ -421,16 +423,18 @@ export default function RecentGames({
                                     && game.playerOrder.playerTwo.originalColor
                                       === (game.result as "white" | "black")}
                                 />
-                                {game.result === "draw" && <span className="text-gray-600 ml-2">½-½</span>}
+                                {game.result === "draw" && (
+                                  <span className="text-gray-600 dark:text-gray-300 ml-2">½-½</span>
+                                )}
                               </div>
                             </TableCell>
-                            <TableCell className="border border-[#dee2e6] p-3 text-center">
+                            <TableCell className="border border-border p-3 text-center">
                               <span
                                 className={cn(
                                   "px-2 py-1 rounded text-xs font-medium",
                                   game.rated
-                                    ? "bg-green-100 text-green-800"
-                                    : "bg-gray-100 text-gray-800",
+                                    ? "bg-green-100 text-green-800 dark:bg-green-500/20 dark:text-green-200"
+                                    : "bg-gray-100 text-gray-800 dark:bg-gray-800/60 dark:text-gray-200",
                                 )}
                               >
                                 {game.rated ? "Rated" : "Unrated"}


### PR DESCRIPTION
## Summary
- add a HiveThemeWatcher client component to follow the user’s preferred color scheme when visiting Hive pages
- restyle the Hive layout, tabs, and tables to use theme-aware colors
- update recent games styling so both light and dark themes remain readable

## Testing
- pnpm exec next lint

------
https://chatgpt.com/codex/tasks/task_e_68cb32667cc8832b816f6581c3c92b27