### PR TITLE
Use feed library for Hive Atom feed

### DIFF
--- a/app/hive/recent/feed.xml/route.ts
+++ b/app/hive/recent/feed.xml/route.ts
@@ -1,0 +1,114 @@
+import { Feed } from "feed"
+import { loadRecentHiveData } from "../../../../lib/hiveRecent"
+import { withBasePath } from "../../../../lib/basePath"
+
+export const dynamic = "force-static"
+export const runtime = "nodejs"
+
+const FEED_ID = "tag:cnc,2024-01-01:recent-hive-games"
+const FEED_TITLE = "Recent Hive Games"
+const FEED_DESCRIPTION = "Highlighted recent Hive games involving CNC players"
+const MAX_ENTRIES = 50
+
+type GameResult = "white" | "black" | "draw"
+
+function resultScore(result: GameResult): string {
+  switch (result) {
+    case "white":
+      return "1-0"
+    case "black":
+      return "0-1"
+    case "draw":
+    default:
+      return "½-½"
+  }
+}
+
+function resultSummary(result: GameResult, white: string, black: string): string {
+  switch (result) {
+    case "white":
+      return `${white} defeats ${black}`
+    case "black":
+      return `${black} defeats ${white}`
+    default:
+      return `${white} draws ${black}`
+  }
+}
+
+function parseTimestamp(timestamp?: string): Date {
+  if (!timestamp) return new Date()
+  const parsed = Date.parse(timestamp)
+  if (Number.isNaN(parsed)) return new Date()
+  return new Date(parsed)
+}
+
+function getSiteOrigin(): string | undefined {
+  const envOrigin = process.env.NEXT_PUBLIC_SITE_URL || process.env.SITE_URL
+  if (envOrigin) {
+    return envOrigin.replace(/\/$/, "")
+  }
+  return undefined
+}
+
+export function GET(): Response {
+  const { recentGames } = loadRecentHiveData()
+  const siteOrigin = getSiteOrigin()
+  const feedPath = withBasePath("/hive/recent/feed.xml")
+  const pagePath = withBasePath("/hive/recent/")
+
+  const updatedDate = recentGames.length > 0
+    ? parseTimestamp(recentGames[0].timestamp)
+    : new Date()
+
+  const feedUrl = siteOrigin ? `${siteOrigin}${feedPath}` : feedPath
+  const pageUrl = siteOrigin ? `${siteOrigin}${pagePath}` : pagePath
+
+  const feed = new Feed({
+    id: FEED_ID,
+    title: FEED_TITLE,
+    description: FEED_DESCRIPTION,
+    updated: updatedDate,
+    link: pageUrl,
+    feedLinks: { atom: feedUrl },
+    author: { name: FEED_TITLE },
+    copyright: FEED_TITLE,
+  })
+
+  recentGames.slice(0, MAX_ENTRIES).forEach((game) => {
+    const gameUrl = `https://hivegame.com/game/${game.game_id}`
+    const publishedDate = parseTimestamp(game.timestamp)
+    const entryYear = publishedDate.getUTCFullYear()
+    const entryId = `tag:hivegame.com,${entryYear}:${game.game_id}`
+    const score = resultScore(game.result)
+
+    const summaryText = `${resultSummary(
+      game.result,
+      game.white_player,
+      game.black_player,
+    )} (${score}). ${game.rated ? "Rated" : "Unrated"}${
+      game.event ? ` — Event: ${game.event}` : ""
+    }.`
+
+    feed.addItem({
+      id: entryId,
+      title: `${game.white_player} vs ${game.black_player} (${score})`,
+      link: gameUrl,
+      date: publishedDate,
+      description: summaryText,
+      content: summaryText,
+      author: [
+        { name: game.white_player },
+        { name: game.black_player },
+      ],
+    })
+  })
+
+  const atomFeed = feed.atom1()
+
+  return new Response(atomFeed, {
+    headers: {
+      "Content-Type": "application/atom+xml; charset=utf-8",
+      "Cache-Control": "public, max-age=300",
+    },
+  })
+}

--- a/app/hive/recent/page.tsx
+++ b/app/hive/recent/page.tsx
@@ -1,252 +1,10 @@
-import { parse as parseToml } from "@ltd/j-toml"
-import fs from "fs"
 import Head from "next/head"
-import Link from "next/link"
-import path from "path"
 import RecentGames from "../../../components/RecentGames"
-import type { Config, GameStats, Player } from "../../../lib/hiveData"
-import { extractGameIdFromUrl } from "../../../lib/hiveData"
+import { loadRecentHiveData } from "../../../lib/hiveRecent"
+import { withBasePath } from "../../../lib/basePath"
 
-type RawCacheGame = {
-  game_id: string
-  white_player: { username: string }
-  black_player: { username: string }
-  game_status:
-    | { Finished: { Winner: "White" | "Black" } }
-    | { Finished: "Draw" }
-  rated: boolean
-  created_at: string
-  last_interaction?: string
-}
-
-type CacheFile = {
-  players: Record<string, { last_fetch: string; games: RawCacheGame[] }>
-}
-
-function tagKnownPlayerId(id: string): string {
-  return `player#${id}`
-}
-
-function tagHG(nick: string): string {
-  return `HG#${nick.replace(/^HG#/, "")}`
-}
-
-function computeConfigAndKnownPlayers(tomlText: string): {
-  config: Config
-  knownPlayers: Array<{
-    id: string
-    display_name: string
-    groups: string[]
-    hivegame_nicks: string[]
-    hivegame_nick: string
-  }>
-  nickToKnownId: Map<string, string>
-} {
-  const data: any = parseToml(tomlText)
-
-  const settings = data.settings || {}
-  const config: Config = {
-    group_order: Array.isArray(settings.group_order)
-      ? settings.group_order
-      : [],
-    highlight_games: Array.isArray(settings.highlight_games)
-      ? settings.highlight_games
-      : [],
-  }
-
-  const playersObj: Record<string, any> = data.players || {}
-  const knownPlayers: Array<{
-    id: string
-    display_name: string
-    groups: string[]
-    hivegame_nicks: string[]
-    hivegame_nick: string
-  }> = []
-  const nickToKnownId = new Map<string, string>()
-
-  for (const [playerId, meta] of Object.entries(playersObj)) {
-    const display_name = (meta as any).display_name as string
-    const groups = ((meta as any).groups as string[]) || []
-    const hivegame = ((meta as any).hivegame as string[]) || []
-    const hivegame_current = ((meta as any).hivegame_current as string) || hivegame[0]
-
-    const id = tagKnownPlayerId(playerId)
-    const hivegame_nicks = hivegame.map((n) => tagHG(n))
-    const hivegame_nick = tagHG(hivegame_current)
-
-    for (const nick of hivegame) {
-      nickToKnownId.set(nick.toLowerCase(), id)
-    }
-
-    knownPlayers.push({
-      id,
-      display_name,
-      groups,
-      hivegame_nicks,
-      hivegame_nick,
-    })
-  }
-
-  return { config, knownPlayers, nickToKnownId }
-}
-
-function loadAndDedupGames(cacheText: string): RawCacheGame[] {
-  const parsed = JSON.parse(cacheText) as CacheFile
-  const allGames: RawCacheGame[] = []
-  for (const player of Object.values(parsed.players || {})) {
-    if (!player || !Array.isArray(player.games)) continue
-    allGames.push(...player.games)
-  }
-
-  const byId = new Map<string, RawCacheGame>()
-  for (const g of allGames) {
-    if (!byId.has(g.game_id)) byId.set(g.game_id, g)
-  }
-  return Array.from(byId.values())
-}
-
-function resultLabel(game: RawCacheGame): "white" | "black" | "draw" {
-  const gs: any = game.game_status
-  if (typeof gs?.Finished === "string" && gs.Finished === "Draw") return "draw"
-  const winner = (gs?.Finished?.Winner as string) || ""
-  return winner === "White" ? "white" : "black"
-}
-
-export default async function RecentPage() {
-  const root = process.cwd()
-  const tomlPath = path.join(root, "data", "hive.toml")
-  const cachePath = path.join(root, "data", "hive_games_cache.json")
-
-  const tomlText = fs.readFileSync(tomlPath, "utf8")
-  const cacheText = fs.readFileSync(cachePath, "utf8")
-
-  const { config, knownPlayers, nickToKnownId } = computeConfigAndKnownPlayers(tomlText)
-  const games = loadAndDedupGames(cacheText)
-
-  // Parse game metadata from TOML
-  const parsedToml = parseToml(tomlText) as any
-  const gameMetadata: Array<{ url: string; event: string }> = parsedToml.games || []
-
-  // Create a map from game ID to event (only /game/{id} urls)
-  const gameIdToEvent = new Map<string, string>()
-  for (const m of gameMetadata) {
-    const id = extractGameIdFromUrl(m.url)
-    if (id && m.event) gameIdToEvent.set(id, m.event)
-  }
-
-  // Identify outsiders (only opponents of selected groups)
-  const settingsAny: any = (parseToml(tomlText) as any)?.settings
-  const fetchOutsiders: string[] = Array.isArray(settingsAny?.fetch_outsiders)
-    ? settingsAny.fetch_outsiders
-    : []
-  const playerIdToGroups = new Map(
-    knownPlayers.map((p) => [p.id, p.groups as string[]]),
-  )
-
-  const outsiders = new Set<string>()
-  for (const g of games) {
-    const white = g.white_player.username
-    const black = g.black_player.username
-    const whiteKnown = nickToKnownId.get(white.toLowerCase())
-    const blackKnown = nickToKnownId.get(black.toLowerCase())
-
-    if (whiteKnown && !blackKnown) {
-      const topGroup = (playerIdToGroups.get(whiteKnown) || [])[0]
-      if (fetchOutsiders.includes(topGroup)) outsiders.add(black)
-    } else if (!whiteKnown && blackKnown) {
-      const topGroup = (playerIdToGroups.get(blackKnown) || [])[0]
-      if (fetchOutsiders.includes(topGroup)) outsiders.add(white)
-    }
-  }
-
-  // Build players list
-  const players: Player[] = []
-  for (const kp of knownPlayers) {
-    players.push({
-      id: kp.id,
-      display_name: kp.display_name,
-      groups: kp.groups,
-      hivegame_nick: kp.hivegame_nick,
-      hivegame_nicks: kp.hivegame_nicks,
-      is_known: true,
-      total_games: 0, // fill next
-    })
-  }
-  for (const nick of outsiders) {
-    players.push({
-      id: tagHG(nick),
-      display_name: `@${nick.replace(/^HG#/, "")}`,
-      groups: ["(outsider)"],
-      hivegame_nick: tagHG(nick),
-      hivegame_nicks: [tagHG(nick)],
-      is_known: false,
-      total_games: 0, // fill next
-    })
-  }
-
-  // Build nick -> game_ids set for counting unique games
-  const nickToGameIds = new Map<string, Set<string>>()
-  for (const g of games) {
-    const wid = g.white_player.username
-    const bid = g.black_player.username
-    if (!nickToGameIds.has(wid)) nickToGameIds.set(wid, new Set())
-    if (!nickToGameIds.has(bid)) nickToGameIds.set(bid, new Set())
-    nickToGameIds.get(wid)!.add(g.game_id)
-    nickToGameIds.get(bid)!.add(g.game_id)
-  }
-
-  // Fill total_games
-  for (const p of players) {
-    if (p.is_known) {
-      const uniq = new Set<string>()
-      for (const tagged of p.hivegame_nicks) {
-        const nick = tagged.replace(/^HG#/, "")
-        const s = nickToGameIds.get(nick)
-        if (s) { for (const gid of s) uniq.add(gid) }
-      }
-      p.total_games = uniq.size
-    } else {
-      const nick = p.hivegame_nick.replace(/^HG#/, "")
-      p.total_games = nickToGameIds.get(nick)?.size || 0
-    }
-  }
-
-  // Prepare recent games data
-  const recentGames = games
-    .map((g) => {
-      const whiteNick = g.white_player.username
-      const blackNick = g.black_player.username
-      const whiteKnownId = nickToKnownId.get(whiteNick.toLowerCase())
-      const blackKnownId = nickToKnownId.get(blackNick.toLowerCase())
-
-      // Check if players belong to highlighted groups
-      const whiteHighlighted = whiteKnownId
-        ? (playerIdToGroups.get(whiteKnownId) || []).some((group) => config.highlight_games.includes(group))
-        : false
-      const blackHighlighted = blackKnownId
-        ? (playerIdToGroups.get(blackKnownId) || []).some((group) => config.highlight_games.includes(group))
-        : false
-
-      // Only include games where at least one player is in a highlighted group
-      if (!whiteHighlighted && !blackHighlighted) return null
-
-      return {
-        game_id: g.game_id,
-        white_player: whiteNick,
-        black_player: blackNick,
-        white_known: whiteKnownId !== undefined,
-        black_known: blackKnownId !== undefined,
-        result: resultLabel(g),
-        rated: g.rated,
-        timestamp: g.last_interaction || g.created_at,
-        event: gameIdToEvent.get(g.game_id) || null,
-      }
-    })
-    .filter((g): g is NonNullable<typeof g> => g !== null)
-    .sort((a, b) => {
-      // Sort by timestamp (newest first)
-      return Date.parse(b.timestamp) - Date.parse(a.timestamp)
-    })
+export default function RecentPage() {
+  const { config, knownPlayers, recentGames } = loadRecentHiveData()
 
   return (
     <>
@@ -257,13 +15,19 @@ export default async function RecentPage() {
           content="Recent Hive games with highlighted players"
         />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link
+          rel="alternate"
+          type="application/atom+xml"
+          href={withBasePath("/hive/recent/feed.xml")}
+          title="Recent Hive Games"
+        />
       </Head>
       <main className="bg-background text-foreground">
         <div className="w-[100vw] m-0 bg-background text-foreground rounded-none shadow-none overflow-visible">
           <div className="p-5">
             <RecentGames
               games={recentGames}
-              knownPlayers={players.filter((p) => p.is_known)}
+              knownPlayers={knownPlayers}
               highlightGroups={config.highlight_games}
             />
           </div>

--- a/components/RecentGames.tsx
+++ b/components/RecentGames.tsx
@@ -1,21 +1,12 @@
 "use client"
 
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
+import type { RecentHiveGame } from "@/lib/hiveRecent"
 import { cn } from "@/lib/utils"
 import Link from "next/link"
 import type { Player } from "../lib/hiveData"
 
-type RecentGame = {
-  game_id: string
-  white_player: string
-  black_player: string
-  white_known: boolean
-  black_known: boolean
-  result: "white" | "black" | "draw"
-  rated: boolean
-  timestamp?: string
-  event: string | null
-}
+type RecentGame = RecentHiveGame
 
 type RecentGamesProps = {
   games: RecentGame[]

--- a/lib/basePath.ts
+++ b/lib/basePath.ts
@@ -1,0 +1,31 @@
+const FALLBACK_BASE_PATH = "/cnc"
+
+function normalizeBasePath(value: string | undefined): string {
+  if (!value) return ""
+  if (value === "/") return ""
+  const trimmed = value.endsWith("/") ? value.slice(0, -1) : value
+  return trimmed.startsWith("/") ? trimmed : `/${trimmed}`
+}
+
+export function getBasePath(): string {
+  const candidates = [
+    process.env.NEXT_PUBLIC_BASE_PATH,
+    process.env.BASE_PATH,
+    process.env.__NEXT_ROUTER_BASEPATH,
+  ]
+
+  for (const candidate of candidates) {
+    if (candidate !== undefined) {
+      return normalizeBasePath(candidate)
+    }
+  }
+
+  return normalizeBasePath(FALLBACK_BASE_PATH)
+}
+
+export function withBasePath(path: string): string {
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`
+  const basePath = getBasePath()
+  if (!basePath) return normalizedPath
+  return `${basePath}${normalizedPath}`
+}

--- a/lib/hiveRecent.ts
+++ b/lib/hiveRecent.ts
@@ -1,0 +1,284 @@
+import { parse as parseToml } from "@ltd/j-toml"
+import fs from "fs"
+import path from "path"
+import type { Config, Player } from "./hiveData"
+import { extractGameIdFromUrl } from "./hiveData"
+
+type RawCacheGame = {
+  game_id: string
+  white_player: { username: string }
+  black_player: { username: string }
+  game_status:
+    | { Finished: { Winner: "White" | "Black" } }
+    | { Finished: "Draw" }
+  rated: boolean
+  created_at: string
+  last_interaction?: string
+}
+
+type CacheFile = {
+  players: Record<string, { last_fetch: string; games: RawCacheGame[] }>
+}
+
+type KnownPlayerMeta = {
+  id: string
+  display_name: string
+  groups: string[]
+  hivegame_nicks: string[]
+  hivegame_nick: string
+}
+
+export type RecentHiveGame = {
+  game_id: string
+  white_player: string
+  black_player: string
+  white_known: boolean
+  black_known: boolean
+  result: "white" | "black" | "draw"
+  rated: boolean
+  timestamp: string
+  event: string | null
+}
+
+export type HiveRecentData = {
+  config: Config
+  players: Player[]
+  knownPlayers: Player[]
+  recentGames: RecentHiveGame[]
+}
+
+function tagKnownPlayerId(id: string): string {
+  return `player#${id}`
+}
+
+function tagHG(nick: string): string {
+  return `HG#${nick.replace(/^HG#/, "")}`
+}
+
+function computeConfigAndKnownPlayers(tomlText: string): {
+  config: Config
+  knownPlayers: KnownPlayerMeta[]
+  nickToKnownId: Map<string, string>
+} {
+  const data: any = parseToml(tomlText)
+
+  const settings = data.settings || {}
+  const config: Config = {
+    group_order: Array.isArray(settings.group_order) ? settings.group_order : [],
+    highlight_games: Array.isArray(settings.highlight_games)
+      ? settings.highlight_games
+      : [],
+  }
+
+  const playersObj: Record<string, any> = data.players || {}
+  const knownPlayers: KnownPlayerMeta[] = []
+  const nickToKnownId = new Map<string, string>()
+
+  for (const [playerId, meta] of Object.entries(playersObj)) {
+    const display_name = (meta as any).display_name as string
+    const groups = ((meta as any).groups as string[]) || []
+    const hivegame = ((meta as any).hivegame as string[]) || []
+    const hivegame_current = ((meta as any).hivegame_current as string) || hivegame[0]
+
+    const id = tagKnownPlayerId(playerId)
+    const hivegame_nicks = hivegame.map((n) => tagHG(n))
+    const hivegame_nick = tagHG(hivegame_current)
+
+    for (const nick of hivegame) {
+      nickToKnownId.set(nick.toLowerCase(), id)
+    }
+
+    knownPlayers.push({
+      id,
+      display_name,
+      groups,
+      hivegame_nicks,
+      hivegame_nick,
+    })
+  }
+
+  return { config, knownPlayers, nickToKnownId }
+}
+
+function loadAndDedupGames(cacheText: string): RawCacheGame[] {
+  const parsed = JSON.parse(cacheText) as CacheFile
+  const allGames: RawCacheGame[] = []
+  for (const player of Object.values(parsed.players || {})) {
+    if (!player || !Array.isArray(player.games)) continue
+    allGames.push(...player.games)
+  }
+
+  const byId = new Map<string, RawCacheGame>()
+  for (const g of allGames) {
+    if (!byId.has(g.game_id)) byId.set(g.game_id, g)
+  }
+  return Array.from(byId.values())
+}
+
+function resultLabel(game: RawCacheGame): "white" | "black" | "draw" {
+  const gs: any = game.game_status
+  if (typeof gs?.Finished === "string" && gs.Finished === "Draw") return "draw"
+  const winner = (gs?.Finished?.Winner as string) || ""
+  return winner === "White" ? "white" : "black"
+}
+
+function buildPlayerList(
+  knownMeta: KnownPlayerMeta[],
+  outsiders: Set<string>,
+): Player[] {
+  const players: Player[] = []
+  for (const kp of knownMeta) {
+    players.push({
+      id: kp.id,
+      display_name: kp.display_name,
+      groups: kp.groups,
+      hivegame_nick: kp.hivegame_nick,
+      hivegame_nicks: kp.hivegame_nicks,
+      is_known: true,
+      total_games: 0,
+    })
+  }
+  for (const nick of outsiders) {
+    players.push({
+      id: tagHG(nick),
+      display_name: `@${nick.replace(/^HG#/, "")}`,
+      groups: ["(outsider)"],
+      hivegame_nick: tagHG(nick),
+      hivegame_nicks: [tagHG(nick)],
+      is_known: false,
+      total_games: 0,
+    })
+  }
+  return players
+}
+
+function countGamesForPlayers(players: Player[], games: RawCacheGame[]) {
+  const nickToGameIds = new Map<string, Set<string>>()
+  for (const g of games) {
+    const wid = g.white_player.username
+    const bid = g.black_player.username
+    if (!nickToGameIds.has(wid)) nickToGameIds.set(wid, new Set())
+    if (!nickToGameIds.has(bid)) nickToGameIds.set(bid, new Set())
+    nickToGameIds.get(wid)!.add(g.game_id)
+    nickToGameIds.get(bid)!.add(g.game_id)
+  }
+
+  for (const p of players) {
+    if (p.is_known) {
+      const uniq = new Set<string>()
+      for (const tagged of p.hivegame_nicks) {
+        const nick = tagged.replace(/^HG#/, "")
+        const s = nickToGameIds.get(nick)
+        if (s) {
+          for (const gid of s) uniq.add(gid)
+        }
+      }
+      p.total_games = uniq.size
+    } else {
+      const nick = p.hivegame_nick.replace(/^HG#/, "")
+      p.total_games = nickToGameIds.get(nick)?.size || 0
+    }
+  }
+}
+
+function sortByTimestampDesc(a: RecentHiveGame, b: RecentHiveGame): number {
+  const parse = (value?: string) => {
+    if (!value) return 0
+    const t = Date.parse(value)
+    return Number.isNaN(t) ? 0 : t
+  }
+  return parse(b.timestamp) - parse(a.timestamp)
+}
+
+export function loadRecentHiveData(): HiveRecentData {
+  const root = process.cwd()
+  const tomlPath = path.join(root, "data", "hive.toml")
+  const cachePath = path.join(root, "data", "hive_games_cache.json")
+
+  const tomlText = fs.readFileSync(tomlPath, "utf8")
+  const cacheText = fs.readFileSync(cachePath, "utf8")
+
+  const { config, knownPlayers: knownMeta, nickToKnownId } =
+    computeConfigAndKnownPlayers(tomlText)
+  const games = loadAndDedupGames(cacheText)
+
+  const parsedToml = parseToml(tomlText) as any
+  const gameMetadata: Array<{ url: string; event: string }> = parsedToml.games || []
+
+  const gameIdToEvent = new Map<string, string>()
+  for (const m of gameMetadata) {
+    const id = extractGameIdFromUrl(m.url)
+    if (id && m.event) gameIdToEvent.set(id, m.event)
+  }
+
+  const settingsAny: any = parsedToml?.settings
+  const fetchOutsiders: string[] = Array.isArray(settingsAny?.fetch_outsiders)
+    ? settingsAny.fetch_outsiders
+    : []
+  const playerIdToGroups = new Map(
+    knownMeta.map((p) => [p.id, p.groups as string[]]),
+  )
+
+  const outsiders = new Set<string>()
+  for (const g of games) {
+    const white = g.white_player.username
+    const black = g.black_player.username
+    const whiteKnown = nickToKnownId.get(white.toLowerCase())
+    const blackKnown = nickToKnownId.get(black.toLowerCase())
+
+    if (whiteKnown && !blackKnown) {
+      const topGroup = (playerIdToGroups.get(whiteKnown) || [])[0]
+      if (fetchOutsiders.includes(topGroup)) outsiders.add(black)
+    } else if (!whiteKnown && blackKnown) {
+      const topGroup = (playerIdToGroups.get(blackKnown) || [])[0]
+      if (fetchOutsiders.includes(topGroup)) outsiders.add(white)
+    }
+  }
+
+  const players = buildPlayerList(knownMeta, outsiders)
+  countGamesForPlayers(players, games)
+
+  const knownPlayers = players.filter((p) => p.is_known)
+
+  const recentGames = games
+    .map((g) => {
+      const whiteNick = g.white_player.username
+      const blackNick = g.black_player.username
+      const whiteKnownId = nickToKnownId.get(whiteNick.toLowerCase())
+      const blackKnownId = nickToKnownId.get(blackNick.toLowerCase())
+
+      const whiteHighlighted = whiteKnownId
+        ? (playerIdToGroups.get(whiteKnownId) || []).some((group) =>
+            config.highlight_games.includes(group),
+          )
+        : false
+      const blackHighlighted = blackKnownId
+        ? (playerIdToGroups.get(blackKnownId) || []).some((group) =>
+            config.highlight_games.includes(group),
+          )
+        : false
+
+      if (!whiteHighlighted && !blackHighlighted) return null
+
+      return {
+        game_id: g.game_id,
+        white_player: whiteNick,
+        black_player: blackNick,
+        white_known: whiteKnownId !== undefined,
+        black_known: blackKnownId !== undefined,
+        result: resultLabel(g),
+        rated: g.rated,
+        timestamp: g.last_interaction || g.created_at,
+        event: gameIdToEvent.get(g.game_id) || null,
+      }
+    })
+    .filter((g): g is RecentHiveGame => g !== null)
+    .sort(sortByTimestampDesc)
+
+  return {
+    config,
+    players,
+    knownPlayers,
+    recentGames,
+  }
+}

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "d3": "^7.9.0",
+    "feed": "^5.1.0",
     "lucide-react": "^0.542.0",
     "next": "^15.5.0",
     "papaparse": "^5.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       d3:
         specifier: ^7.9.0
         version: 7.9.0
+      feed:
+        specifier: ^5.1.0
+        version: 5.1.0
       lucide-react:
         specifier: ^0.542.0
         version: 0.542.0(react@19.1.1)
@@ -2406,6 +2409,10 @@ packages:
       picomatch:
         optional: true
 
+  feed@5.1.0:
+    resolution: {integrity: sha512-qGNhgYygnefSkAHHrNHqC7p3R8J0/xQDS/cYUud8er/qD9EFGWyCdUDfULHTJQN1d3H3WprzVwMc9MfB4J50Wg==}
+    engines: {node: '>=20', pnpm: '>=10'}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3406,6 +3413,9 @@ packages:
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
+  sax@1.4.1:
+    resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
+
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
 
@@ -3896,6 +3906,10 @@ packages:
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
+
+  xml-js@1.6.11:
+    resolution: {integrity: sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==}
+    hasBin: true
 
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
@@ -6402,6 +6416,10 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.3
 
+  feed@5.1.0:
+    dependencies:
+      xml-js: 1.6.11
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -7581,6 +7599,8 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
+  sax@1.4.1: {}
+
   scheduler@0.26.0: {}
 
   semver@6.3.1: {}
@@ -8172,6 +8192,10 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
+
+  xml-js@1.6.11:
+    dependencies:
+      sax: 1.4.1
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary
- replace the hand-built Atom XML in the Hive recent feed route with the `feed` package and reuse existing helpers to populate entries
- add the `feed` dependency so the feed generation logic can rely on a maintained library

## Testing
- pnpm exec tsc --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68cba6308578832ba6391672bbb23bfe