### PR TITLE
Expose Hive feed link and add discovery tests

### DIFF
--- a/app/hive/recent/page.test.tsx
+++ b/app/hive/recent/page.test.tsx
@@ -1,0 +1,76 @@
+import React from "react"
+import { renderToStaticMarkup } from "react-dom/server"
+import { describe, expect, it, vi } from "vitest"
+import { withBasePath } from "../../../lib/basePath"
+
+(globalThis as any).React = React
+
+vi.mock("../../../lib/hiveRecent", () => ({
+  loadRecentHiveData: () => ({
+    config: { group_order: [], highlight_games: [] },
+    knownPlayers: [],
+    players: [],
+    recentGames: [],
+  }),
+}))
+
+vi.mock("../../../components/RecentGames", () => ({
+  __esModule: true,
+  default: function MockRecentGames() {
+    return <div data-testid="recent-games" />
+  },
+}))
+
+import RecentPage, { metadata } from "./page"
+
+type AlternateLinkDescriptor = { title?: string; url: string | URL }
+
+type AlternateEntry =
+  | string
+  | URL
+  | AlternateLinkDescriptor[]
+  | null
+  | undefined
+
+function normalizeAlternate(entry: AlternateEntry): { title?: string; url: string }[] {
+  if (!entry) return []
+  if (Array.isArray(entry)) {
+    return entry.map(({ title, url }) => ({
+      title,
+      url: url instanceof URL ? url.toString() : url,
+    }))
+  }
+  return [
+    {
+      url: entry instanceof URL ? entry.toString() : entry,
+    },
+  ]
+}
+
+describe("Recent Hive feed discovery", () => {
+  it("describes the feed via metadata alternates", () => {
+    const types = metadata.alternates?.types ?? {}
+    const expectedUrl = withBasePath("/hive/recent/feed.xml")
+
+    const atomEntries = normalizeAlternate(types["application/atom+xml"])
+    const rssEntries = normalizeAlternate(types["application/rss+xml"])
+
+    const matcher = expect.arrayContaining([
+      expect.objectContaining({
+        url: expectedUrl,
+        title: expect.stringMatching(/Recent Hive games feed/i),
+      }),
+    ])
+
+    expect(atomEntries).toEqual(matcher)
+    expect(rssEntries).toEqual(matcher)
+  })
+
+  it("renders a direct subscription link to the feed", () => {
+    const html = renderToStaticMarkup(<RecentPage />)
+    const expectedHref = withBasePath("/hive/recent/feed.xml")
+
+    expect(html).toContain(`href="${expectedHref}"`)
+    expect(html).toContain("Recent Hive games feed")
+  })
+})

--- a/app/hive/recent/page.tsx
+++ b/app/hive/recent/page.tsx
@@ -1,30 +1,46 @@
-import Head from "next/head"
+import type { Metadata } from "next"
 import RecentGames from "../../../components/RecentGames"
-import { loadRecentHiveData } from "../../../lib/hiveRecent"
 import { withBasePath } from "../../../lib/basePath"
+import { loadRecentHiveData } from "../../../lib/hiveRecent"
+
+const RECENT_HIVE_FEED_PATH = "/hive/recent/feed.xml"
+const RECENT_HIVE_PAGE_PATH = "/hive/recent/"
+const RECENT_HIVE_FEED_LABEL = "Recent Hive games feed"
+
+const recentHiveFeedUrl = withBasePath(RECENT_HIVE_FEED_PATH)
+const recentHivePageUrl = withBasePath(RECENT_HIVE_PAGE_PATH)
+
+export const metadata: Metadata = {
+  title: "Recent Hive Games",
+  description: "Recent Hive games with highlighted players",
+  alternates: {
+    canonical: recentHivePageUrl,
+    types: {
+      "application/atom+xml": [
+        { title: RECENT_HIVE_FEED_LABEL, url: recentHiveFeedUrl },
+      ],
+      "application/rss+xml": [
+        { title: RECENT_HIVE_FEED_LABEL, url: recentHiveFeedUrl },
+      ],
+    },
+  },
+}
 
 export default function RecentPage() {
   const { config, knownPlayers, recentGames } = loadRecentHiveData()
 
   return (
     <>
-      <Head>
-        <title>Recent Hive Games</title>
-        <meta
-          name="description"
-          content="Recent Hive games with highlighted players"
-        />
-        <meta name="viewport" content="width=device-width, initial-scale=1" />
-        <link
-          rel="alternate"
-          type="application/atom+xml"
-          href={withBasePath("/hive/recent/feed.xml")}
-          title="Recent Hive Games"
-        />
-      </Head>
       <main className="bg-background text-foreground">
         <div className="w-[100vw] m-0 bg-background text-foreground rounded-none shadow-none overflow-visible">
-          <div className="p-5">
+          <div className="p-5 space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Subscribe to the{" "}
+              <a className="underline" href={recentHiveFeedUrl} rel="alternate">
+                {RECENT_HIVE_FEED_LABEL}
+              </a>
+              .
+            </p>
             <RecentGames
               games={recentGames}
               knownPlayers={knownPlayers}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./build/app/types/routes.d.ts" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- expose the recent Hive feed via metadata alternates and a visible link on the page
- include an RSS media-type alias that points at the Atom feed URL
- add Vitest coverage to ensure the metadata and rendered markup advertise the feed

## Testing
- pnpm vitest run
- pnpm next build

------
https://chatgpt.com/codex/tasks/task_e_68cc20aabcdc832bbe97f041ef5da8ab